### PR TITLE
chore: Disable the option of opening github issue based on OWASP-ZAP …

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -67,6 +67,7 @@ jobs:
         with:
           target: "https://www.saucedemo.com/"
           docker_name: "owasp/zap2docker-stable:latest"
+          allow_issue_writing: false
 
       - name: Remove OWASP Scan Docker Container
         if: always()


### PR DESCRIPTION
chore: Disable the option of opening GitHub issue based on OWASP-ZAP baseline scan.

Contributes
to: camelotls/actions-npm-audit #64

Signed-off-by:
Panagiotis Megremis
<pmegremis@gmail.com>